### PR TITLE
Initial support for conditions for AzureMachinePool

### DIFF
--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -297,7 +297,7 @@ spec:
             description: AzureMachinePoolStatus defines the observed state of AzureMachinePool
             properties:
               conditions:
-                description: Conditions defines current service state of the AzureMachine.
+                description: Conditions defines current service state of the AzureMachinePool.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -296,8 +296,52 @@ spec:
           status:
             description: AzureMachinePoolStatus defines the observed state of AzureMachinePool
             properties:
+              conditions:
+                description: Conditions defines current service state of the AzureMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
               failureMessage:
-                description: "ErrorMessage will be set in the event that there is
+                description: "FailureMessage will be set in the event that there is
                   a terminal problem reconciling the MachinePool and will contain
                   a more verbose string suitable for logging and human consumption.
                   \n This field should not be set for transitive errors that a controller
@@ -313,9 +357,9 @@ spec:
                   output."
                 type: string
               failureReason:
-                description: "ErrorReason will be set in the event that there is a
-                  terminal problem reconciling the MachinePool and will contain a
-                  succinct value suitable for machine interpretation. \n This field
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the MachinePool and will contain
+                  a succinct value suitable for machine interpretation. \n This field
                   should not be set for transitive errors that a controller faces
                   that are expected to be fixed automatically over time (like service
                   outages), but instead indicate that something is fundamentally wrong

--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -135,7 +135,7 @@ type (
 		// +optional
 		FailureMessage *string `json:"failureMessage,omitempty"`
 
-		// Conditions defines current service state of the AzureMachine.
+		// Conditions defines current service state of the AzureMachinePool.
 		// +optional
 		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 	}
@@ -170,12 +170,12 @@ type (
 	}
 )
 
-// GetConditions returns the list of conditions for an AzureCluster API object.
+// GetConditions returns the list of conditions for an AzureMachinePool API object.
 func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
 	return amp.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureCluster object
+// SetConditions will set the given conditions on an AzureMachinePool object
 func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	amp.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -96,7 +97,7 @@ type (
 		// +optional
 		ProvisioningState *infrav1.VMState `json:"provisioningState,omitempty"`
 
-		// ErrorReason will be set in the event that there is a terminal problem
+		// FailureReason will be set in the event that there is a terminal problem
 		// reconciling the MachinePool and will contain a succinct value suitable
 		// for machine interpretation.
 		//
@@ -115,7 +116,7 @@ type (
 		// +optional
 		FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
-		// ErrorMessage will be set in the event that there is a terminal problem
+		// FailureMessage will be set in the event that there is a terminal problem
 		// reconciling the MachinePool and will contain a more verbose string suitable
 		// for logging and human consumption.
 		//
@@ -133,6 +134,10 @@ type (
 		// controller's output.
 		// +optional
 		FailureMessage *string `json:"failureMessage,omitempty"`
+
+		// Conditions defines current service state of the AzureMachine.
+		// +optional
+		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 	}
 
 	// +kubebuilder:object:root=true
@@ -164,6 +169,16 @@ type (
 		Items           []AzureMachinePool `json:"items"`
 	}
 )
+
+// GetConditions returns the list of conditions for an AzureCluster API object.
+func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
+	return amp.Status.Conditions
+}
+
+// SetConditions will set the given conditions on an AzureCluster object
+func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
+	amp.Status.Conditions = conditions
+}
 
 func init() {
 	SchemeBuilder.Register(&AzureMachinePool{}, &AzureMachinePoolList{})

--- a/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	cluster_apiapiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -130,6 +131,13 @@ func (in *AzureMachinePoolStatus) DeepCopyInto(out *AzureMachinePoolStatus) {
 		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)
 		**out = **in
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make(cluster_apiapiv1alpha3.Conditions, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 


### PR DESCRIPTION
This is same PR as the one I already submitted to the upstream CAPZ here https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/978. Adding it here as well to speed it up a bit on our side.

This will make our CAPZ fork diverge a bit, but it should not be for too long.

It basically adds `Status.Conditions` to `AzureMachinePool`, plus few accompanying changes:
- updated generated YAML for `AzureMachinePool`
- updated generated deep copying for `AzureMachinePool`

After merging this, our fork will be tagged with `v0.4.9-gsalpha2`.