### PR TITLE
Add Circle CI build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+
+jobs:
+  build:
+    machine:
+      image: "ubuntu-2004:202010-01"
+    steps:
+      - checkout
+      - run:
+          name: Build the CAPI docker images
+          command: |
+            make docker-build
+      - run:
+          name: Login to QUAY
+          command: |
+            docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io
+      - run:
+          name: Push images
+          command: |
+            docker push quay.io/$CIRCLE_PROJECT_USERNAME/cluster-api-azure-controller:$CIRCLE_SHA1
+workflows:
+  version: 2
+  build_and_update:
+    jobs:
+      - build:
+          context:
+            - architect

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ KUBE_APISERVER=$(TOOLS_BIN_DIR)/kube-apiserver
 ETCD=$(TOOLS_BIN_DIR)/etcd
 
 # Define Docker related variables. Releases should modify and double check these vars.
-REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+REGISTRY ?= quay.io
 STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-azure
 PROD_REGISTRY := us.gcr.io/k8s-artifacts-prod/cluster-api-azure
 IMAGE_NAME ?= cluster-api-azure-controller
-CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
+CONTROLLER_IMG ?= $(REGISTRY)/giantswarm/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
@@ -340,7 +340,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(CIRCLE_SHA1)
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"
 


### PR DESCRIPTION
Adjustment to Makefile and added Circle CI config enables container
build for Giant Swarm CAPZ fork.

These changes are hand-picked from CAPI Hive Sprint changes.