### PR TITLE
Docker images for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,4 @@ workflows:
           # Trigger the job also on git tag.
           filters:
             tags:
-              only: /^v.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,7 @@ workflows:
       - build:
           context:
             - architect
+          # Trigger the job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Push images
           command: |
-            docker push quay.io/$CIRCLE_PROJECT_USERNAME/cluster-api-azure-controller:$CIRCLE_SHA1
+            docker push quay.io/$CIRCLE_PROJECT_USERNAME/cluster-api-azure-controller:${CIRCLE_TAG:-$CIRCLE_SHA1}
 workflows:
   version: 2
   build_and_update:

--- a/Makefile
+++ b/Makefile
@@ -338,12 +338,11 @@ docker-pull-prerequisites:
 	docker pull docker.io/library/golang:1.16
 	docker pull gcr.io/distroless/static:latest
 
-DOCKER_IMAGE_TAG ?= CIRCLE_TAG
-DOCKER_IMAGE_TAG ?= CIRCLE_SHA1
+DOCKER_IMAGE_TAG ?= $(CIRCLE_TAG)
+DOCKER_IMAGE_TAG ?= $(CIRCLE_SHA1)
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	env
 	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(DOCKER_IMAGE_TAG)
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-    set
+	env
 	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):${CIRCLE_TAG:-$CIRCLE_SHA1}
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"

--- a/Makefile
+++ b/Makefile
@@ -338,8 +338,11 @@ docker-pull-prerequisites:
 	docker pull docker.io/library/golang:1.16
 	docker pull gcr.io/distroless/static:latest
 
-DOCKER_IMAGE_TAG ?= $(CIRCLE_TAG)
-DOCKER_IMAGE_TAG ?= $(CIRCLE_SHA1)
+DOCKER_IMAGE_TAG := $(CIRCLE_TAG)
+ifeq ($(DOCKER_IMAGE_TAG),)
+DOCKER_IMAGE_TAG := $(CIRCLE_SHA1)
+endif
+export DOCKER_IMAGE_TAG
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager

--- a/Makefile
+++ b/Makefile
@@ -338,10 +338,13 @@ docker-pull-prerequisites:
 	docker pull docker.io/library/golang:1.16
 	docker pull gcr.io/distroless/static:latest
 
+DOCKER_IMAGE_TAG ?= CIRCLE_TAG
+DOCKER_IMAGE_TAG ?= CIRCLE_SHA1
+
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
 	env
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):${CIRCLE_TAG:-$CIRCLE_SHA1}
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(DOCKER_IMAGE_TAG)
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"
 

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(CIRCLE_SHA1)
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):${CIRCLE_TAG:-$CIRCLE_SHA1}
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"
 

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
+    set
 	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):${CIRCLE_TAG:-$CIRCLE_SHA1}
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"

--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,7 @@ docker-pull-prerequisites:
 	docker pull docker.io/library/golang:1.16
 	docker pull gcr.io/distroless/static:latest
 
+# Determine the docker image tag. Try using the tag first or fallback to the commit SHA.
 DOCKER_IMAGE_TAG := $(CIRCLE_TAG)
 ifeq ($(DOCKER_IMAGE_TAG),)
 DOCKER_IMAGE_TAG := $(CIRCLE_SHA1)


### PR DESCRIPTION
This PR changes the circle CI config to use the git tag name as docker image tag when building.