### PR TITLE
Use VNet resource group for private link NAT IP configs

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -1129,6 +1129,7 @@ func (s *ClusterScope) PrivateLinkSpecs() []azure.ResourceSpecGetter {
 			ResourceGroup:             s.ResourceGroup(),
 			SubscriptionID:            s.SubscriptionID(),
 			Location:                  s.Location(),
+			VNetResourceGroup:         s.Vnet().ResourceGroup,
 			VNet:                      s.Vnet().Name,
 			LoadBalancerName:          s.APIServerLBName(),
 			LBFrontendIPConfigNames:   privateLink.LBFrontendIPConfigNames,

--- a/azure/services/privatelinks/spec.go
+++ b/azure/services/privatelinks/spec.go
@@ -19,6 +19,7 @@ type PrivateLinkSpec struct {
 	ResourceGroup             string
 	SubscriptionID            string
 	Location                  string
+	VNetResourceGroup         string
 	VNet                      string
 	NATIPConfiguration        []NATIPConfiguration
 	LoadBalancerName          string
@@ -88,7 +89,7 @@ func (s *PrivateLinkSpec) Parameters(ctx context.Context, existing interface{}) 
 						fmt.Sprintf(
 							"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s",
 							s.SubscriptionID,
-							s.ResourceGroup,
+							s.VNetResourceGroup,
 							s.VNet,
 							natIPConfiguration.Subnet)),
 				},


### PR DESCRIPTION
Towards #https://github.com/giantswarm/roadmap/issues/2722