### PR TITLE
fix: don't specify rules in aggregated cluster role

### DIFF
--- a/config/rbac/aggregation_role.yaml
+++ b/config/rbac/aggregation_role.yaml
@@ -7,4 +7,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       cluster.x-k8s.io/aggregate-to-capz-manager: "true"
-rules: []


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Fixes an issue where the CAPZ manifests will be continuously reconciled if they
are monitored by an operator which expects its own managed fields to be
unaltered.

By specifying an explicitly empty ruleset we:

- own the rules field
- assert that it is explicitly empty, given that it is atomic

The aggregation controller populates the field itself when it writes the rules
to it, which results in a conflict the next time we reconcile the manifest.

Upstream PR: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6346

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes an issue where capz-manager-role reconciles continuously if managed by an installer which uses server-side apply.
```
